### PR TITLE
add new tables to manage zines

### DIFF
--- a/build-bash.sh
+++ b/build-bash.sh
@@ -1,13 +1,2 @@
 #!/bin/bash
 echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
-
-if [[ "$VERCEL_GIT_COMMIT_REF" == "staging" || "$VERCEL_GIT_COMMIT_REF" == "main"  ]] ; then
-  # Proceed with the build
-    echo "✅ - Build can proceed"
-  exit 1;
-
-else
-  # Don't build
-  echo "🛑 - Build cancelled"
-  exit 0;
-fi

--- a/database.types.ts
+++ b/database.types.ts
@@ -1,0 +1,321 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  public: {
+    Tables: {
+      authors: {
+        Row: {
+          bio: string | null
+          created_at: string | null
+          id: number
+          name: string
+          updated_at: string | null
+          url: string | null
+        }
+        Insert: {
+          bio?: string | null
+          created_at?: string | null
+          id?: number
+          name: string
+          updated_at?: string | null
+          url?: string | null
+        }
+        Update: {
+          bio?: string | null
+          created_at?: string | null
+          id?: number
+          name?: string
+          updated_at?: string | null
+          url?: string | null
+        }
+        Relationships: []
+      }
+      form_uploads: {
+        Row: {
+          author_name: string | null
+          author_url: string | null
+          collection_title: string | null
+          cover_image: string | null
+          created_at: string | null
+          description: string | null
+          id: number
+          is_published: boolean | null
+          pdf_url: string | null
+          tags: Json | null
+          title: string
+          uuid: string | null
+        }
+        Insert: {
+          author_name?: string | null
+          author_url?: string | null
+          collection_title?: string | null
+          cover_image?: string | null
+          created_at?: string | null
+          description?: string | null
+          id?: number
+          is_published?: boolean | null
+          pdf_url?: string | null
+          tags?: Json | null
+          title: string
+          uuid?: string | null
+        }
+        Update: {
+          author_name?: string | null
+          author_url?: string | null
+          collection_title?: string | null
+          cover_image?: string | null
+          created_at?: string | null
+          description?: string | null
+          id?: number
+          is_published?: boolean | null
+          pdf_url?: string | null
+          tags?: Json | null
+          title?: string
+          uuid?: string | null
+        }
+        Relationships: []
+      }
+      library_zines: {
+        Row: {
+          collection_title: string | null
+          cover_image: string | null
+          created_at: string | null
+          description: string | null
+          id: number
+          is_published: boolean | null
+          pdf_url: string | null
+          slug: string | null
+          tags: Json | null
+          title: string
+          updated_at: string | null
+          uuid: string | null
+        }
+        Insert: {
+          collection_title?: string | null
+          cover_image?: string | null
+          created_at?: string | null
+          description?: string | null
+          id?: number
+          is_published?: boolean | null
+          pdf_url?: string | null
+          slug?: string | null
+          tags?: Json | null
+          title: string
+          updated_at?: string | null
+          uuid?: string | null
+        }
+        Update: {
+          collection_title?: string | null
+          cover_image?: string | null
+          created_at?: string | null
+          description?: string | null
+          id?: number
+          is_published?: boolean | null
+          pdf_url?: string | null
+          slug?: string | null
+          tags?: Json | null
+          title?: string
+          updated_at?: string | null
+          uuid?: string | null
+        }
+        Relationships: []
+      }
+      library_zines_authors: {
+        Row: {
+          author_id: number
+          created_at: string | null
+          id: number
+          zine_id: number
+        }
+        Insert: {
+          author_id: number
+          created_at?: string | null
+          id?: number
+          zine_id: number
+        }
+        Update: {
+          author_id?: number
+          created_at?: string | null
+          id?: number
+          zine_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fk_authors"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "authors"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fk_library_zines"
+            columns: ["zine_id"]
+            isOneToOne: false
+            referencedRelation: "library_zines"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      zines: {
+        Row: {
+          author_name: string | null
+          author_url: string | null
+          collection_title: string | null
+          cover_image: string | null
+          created_at: string
+          description: string | null
+          id: number
+          is_published: boolean | null
+          pdf_url: string | null
+          tags: Json | null
+          title: string
+          uuid: string | null
+        }
+        Insert: {
+          author_name?: string | null
+          author_url?: string | null
+          collection_title?: string | null
+          cover_image?: string | null
+          created_at?: string
+          description?: string | null
+          id?: number
+          is_published?: boolean | null
+          pdf_url?: string | null
+          tags?: Json | null
+          title: string
+          uuid?: string | null
+        }
+        Update: {
+          author_name?: string | null
+          author_url?: string | null
+          collection_title?: string | null
+          cover_image?: string | null
+          created_at?: string
+          description?: string | null
+          id?: number
+          is_published?: boolean | null
+          pdf_url?: string | null
+          tags?: Json | null
+          title?: string
+          uuid?: string | null
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type PublicSchema = Database[Extract<keyof Database, "public">]
+
+export type Tables<
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof PublicSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never

--- a/database.types.ts
+++ b/database.types.ts
@@ -124,7 +124,15 @@ export type Database = {
           updated_at?: string | null
           uuid?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "fk_library_zines"
+            columns: ["id"]
+            isOneToOne: false
+            referencedRelation: "library_zines_authors"
+            referencedColumns: ["zine_id"]
+          },
+        ]
       }
       library_zines_authors: {
         Row: {

--- a/src/@types/zine.d.ts
+++ b/src/@types/zine.d.ts
@@ -1,3 +1,13 @@
+type Author = {
+  authors: {
+    id: string;
+    uuid: string;
+    name: string;
+    bio: string;
+    url: string;
+  }
+};
+
 type Zine = {
   id: string;
   uuid: string;
@@ -6,6 +16,5 @@ type Zine = {
   tags: string[];
   cover_image: string;
   pdf_url: string;
-  author_name: string;
-  author_url: string;
+  library_zines_authors: Author[];
 };

--- a/src/@types/zine.d.ts
+++ b/src/@types/zine.d.ts
@@ -1,20 +1,11 @@
-type Author = {
-  authors: {
-    id: string;
-    uuid: string;
-    name: string;
-    bio: string;
-    url: string;
-  }
-};
+import { Tables } from "../../database.types";
 
-type Zine = {
-  id: string;
-  uuid: string;
-  title: string;
-  description: string;
-  tags: string[];
-  cover_image: string;
-  pdf_url: string;
-  library_zines_authors: Author[];
+type Author = Tables<'authors'>;
+
+type LibraryZinesAuthors = {
+  authors: Author;
+}[];
+
+type Zine = Tables<'library_zines'> & {
+  library_zines_authors: LibraryZinesAuthors;
 };

--- a/src/app/zines/[id]/page.tsx
+++ b/src/app/zines/[id]/page.tsx
@@ -2,6 +2,7 @@ import PDFViewer from "@/components/pdf-viewer";
 import { getZineByUuid } from "@/services/zine-service";
 import { getPreviewUrl, getThumbnailUrl } from "@/utils/assets";
 import { limitText } from "@/utils/utils";
+import Link from "next/link";
 
 export async function generateMetadata({
   params,
@@ -21,7 +22,7 @@ export async function generateMetadata({
   const thumbnailUrl = getThumbnailUrl(preview.cover_image);
 
   return {
-    title: `${preview.title} por ${preview.author_name}`,
+    title: `${preview.title} por ${preview.library_zines_authors.map((a) => a.authors.name).join(", ")}`,
     description: preview.description
       ? limitText(preview.description)
       : preview.title,
@@ -70,8 +71,20 @@ export default async function ZinePreview({
   return (
     <div className="flex min-h-screen flex-col items-center w-full mx-auto p-4 md:p-0 gap-16">
       <p className="text-sm">
-        <strong>{preview.title}</strong> por {preview.author_name}
+        <strong>{preview.title}</strong> por {preview.library_zines_authors.map((a) => a.authors.name).join(", ")}
       </p>
+      <div className="flex flex-col items-center">
+      {preview.library_zines_authors.length > 0 && preview.library_zines_authors.map(({authors}) => (
+          <Link
+            key={authors.id}
+            href={authors.url}
+            target="_blank"
+            className="flex items-center justify-center px-3 py-1.5 text-sm font-medium text-black border border-black rounded-md hover:bg-neutral-100 transition"
+          >
+            Conhecer autor: {authors.name}
+          </Link>
+        ))}
+      </div>
       <p className="text-sm max-w-xl text-center">{preview.description}</p>
       <div className="bg-neutral-500 w-full h-screen max-w-xl mx-auto overflow-hidden">
         <PDFViewer url={previewUrl} />

--- a/src/app/zines/[id]/page.tsx
+++ b/src/app/zines/[id]/page.tsx
@@ -1,7 +1,7 @@
 import PDFViewer from "@/components/pdf-viewer";
 import { getZineByUuid } from "@/services/zine-service";
 import { getPreviewUrl, getThumbnailUrl } from "@/utils/assets";
-import { limitText } from "@/utils/utils";
+import { joinAuthors, limitText } from "@/utils/utils";
 import Link from "next/link";
 
 export async function generateMetadata({
@@ -19,10 +19,10 @@ export async function generateMetadata({
     };
   }
 
-  const thumbnailUrl = getThumbnailUrl(preview.cover_image);
+  const thumbnailUrl = preview.cover_image ? getThumbnailUrl(preview.cover_image) : "";
 
   return {
-    title: `${preview.title} por ${preview.library_zines_authors.map((a) => a.authors.name).join(", ")}`,
+    title: `${preview.title} por ${joinAuthors(preview.library_zines_authors)}`,
     description: preview.description
       ? limitText(preview.description)
       : preview.title,
@@ -66,18 +66,18 @@ export default async function ZinePreview({
     );
   }
 
-  const previewUrl = getPreviewUrl(preview.pdf_url);
+  const previewUrl = preview.pdf_url ? getPreviewUrl(preview.pdf_url) : "";
 
   return (
     <div className="flex min-h-screen flex-col items-center w-full mx-auto p-4 md:p-0 gap-16">
       <p className="text-sm">
-        <strong>{preview.title}</strong> por {preview.library_zines_authors.map((a) => a.authors.name).join(", ")}
+        <strong>{preview.title}</strong> por {joinAuthors(preview.library_zines_authors)}
       </p>
-      <div className="flex flex-col items-center">
+      <div className="flex gap-2 flex-wrap justify-center max-w-2xl mx-auto">
       {preview.library_zines_authors.length > 0 && preview.library_zines_authors.map(({authors}) => (
           <Link
             key={authors.id}
-            href={authors.url}
+            href={authors.url || "#"}
             target="_blank"
             className="flex items-center justify-center px-3 py-1.5 text-sm font-medium text-black border border-black rounded-md hover:bg-neutral-100 transition"
           >

--- a/src/components/zine-card.tsx
+++ b/src/components/zine-card.tsx
@@ -1,13 +1,15 @@
 import Image from "next/image";
 import Link from "next/link";
 import { getThumbnailUrl } from "@/utils/assets";
+import { joinAuthors } from "@/utils/utils";
+import { Zine } from "@/@types/zine";
 
 type ZineCardProps = {
   zine: Zine;
 };
 
 const ZineCard: React.FC<ZineCardProps> = ({ zine }) => {
-  const thumbnailUrl = getThumbnailUrl(zine.cover_image);
+  const thumbnailUrl = zine.cover_image ? getThumbnailUrl(zine.cover_image) : "";
   return (
     <div
       className="flex flex-col justify-between bg-white rounded-lg overflow-hidden shadow-sm h-full"
@@ -24,7 +26,7 @@ const ZineCard: React.FC<ZineCardProps> = ({ zine }) => {
         <div className="flex flex-col mt-3 text-center">
           <h1 className="text-lg font-medium">
             {zine.title}{" "}
-            <span className="text-gray-500 text-sm">por {zine.library_zines_authors.map((a) => a.authors.name).join(", ")}</span>
+            <span className="text-gray-500 text-sm">por {joinAuthors(zine.library_zines_authors)}</span>
           </h1>
           <p className="mt-2 text-sm text-gray-600">{zine.description}</p>
         </div>

--- a/src/components/zine-card.tsx
+++ b/src/components/zine-card.tsx
@@ -24,7 +24,7 @@ const ZineCard: React.FC<ZineCardProps> = ({ zine }) => {
         <div className="flex flex-col mt-3 text-center">
           <h1 className="text-lg font-medium">
             {zine.title}{" "}
-            <span className="text-gray-500 text-sm">por {zine.author_name ?? ""}</span>
+            <span className="text-gray-500 text-sm">por {zine.library_zines_authors.map((a) => a.authors.name).join(", ")}</span>
           </h1>
           <p className="mt-2 text-sm text-gray-600">{zine.description}</p>
         </div>
@@ -37,15 +37,6 @@ const ZineCard: React.FC<ZineCardProps> = ({ zine }) => {
         >
           Ver mais
         </Link>
-        {zine.author_url && (
-          <Link
-            href={zine.author_url}
-            target="_blank"
-            className="flex items-center justify-center px-3 py-1.5 text-sm font-medium text-black border border-black rounded-md hover:bg-neutral-100 transition"
-          >
-            Conhecer autor
-          </Link>
-        )}
       </div>
     </div>
   );

--- a/src/services/zine-service.ts
+++ b/src/services/zine-service.ts
@@ -5,8 +5,10 @@ export const getPublishedZines = async (): Promise<Zine[]> => {
   const supabase = await createClient();
 
   const { data, error }: PostgrestResponse<Zine> = await supabase
-    .from("zines")
-    .select("*")
+    .from("library_zines")
+    .select(
+      '*, library_zines_authors (authors (id, name, url))'
+    )
     .eq("is_published", true);
 
   if (error) {
@@ -21,8 +23,10 @@ export const getZineByUuid = async (uuid: string): Promise<Zine | null> => {
   const supabase = await createClient();
 
   const { data, error } = await supabase
-    .from("zines")
-    .select("*")
+    .from("library_zines")
+    .select(
+      '*, library_zines_authors (authors (id, name, url))'
+    )
     .eq("uuid", uuid)
     .eq("is_published", true)
     .single();

--- a/src/services/zine-service.ts
+++ b/src/services/zine-service.ts
@@ -1,3 +1,4 @@
+import { Zine } from "@/@types/zine";
 import { createClient } from "@/utils/supabase/server";
 import { PostgrestResponse } from "@supabase/supabase-js";
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,4 @@
+import { LibraryZinesAuthors } from "@/@types/zine";
 import { redirect } from "next/navigation";
 
 /**
@@ -10,13 +11,18 @@ import { redirect } from "next/navigation";
 export function encodedRedirect(
   type: "error" | "success",
   path: string,
-  message: string,
+  message: string
 ) {
   return redirect(`${path}?${type}=${encodeURIComponent(message)}`);
 }
 
-
 export function limitText(text: string, maxLength: number = 150): string {
   if (text.length <= maxLength) return text;
   return text.slice(0, maxLength).trim() + "...";
+}
+
+export function joinAuthors(
+  library_zines_authors: LibraryZinesAuthors
+): string {
+  return library_zines_authors.map((a) => a.authors.name).join(", ");
 }

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,4 @@
+# Supabase
+.branches
+.temp
+.env

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,278 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "biblioteca-zines"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 15
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+[edge_runtime]
+enabled = true
+# Configure one of the supported request policies: `oneshot`, `per_worker`.
+# Use `oneshot` for hot reload, or `per_worker` for load testing.
+policy = "oneshot"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+
+# Use these configurations to customize your Edge Function.
+# [functions.MY_FUNCTION_NAME]
+# enabled = true
+# verify_jwt = true
+# import_map = "./functions/MY_FUNCTION_NAME/deno.json"
+# Uncomment to specify a custom file path to the entrypoint.
+# Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx
+# entrypoint = "./functions/MY_FUNCTION_NAME/index.ts"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/supabase/migrations/20250123215138_addFormUploadsTable.sql
+++ b/supabase/migrations/20250123215138_addFormUploadsTable.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+CREATE TABLE public.form_uploads (
+    id SERIAL PRIMARY KEY, 
+    title TEXT NOT NULL,
+    author_name TEXT,
+    author_url TEXT,
+    collection_title TEXT,
+    cover_image TEXT,
+    description TEXT,
+    is_published BOOLEAN,
+    pdf_url TEXT,
+    tags JSONB,
+    uuid UUID,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+COMMIT;

--- a/supabase/migrations/20250123215146_addAuthorsTable.sql
+++ b/supabase/migrations/20250123215146_addAuthorsTable.sql
@@ -1,0 +1,71 @@
+
+-- Create the `library_zines` table
+CREATE TABLE public.library_zines (
+    id SERIAL PRIMARY KEY,
+    slug TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT,
+    collection_title TEXT,
+    cover_image TEXT,
+    pdf_url TEXT,
+    tags JSONB,
+    is_published BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW(),
+    uuid UUID DEFAULT gen_random_uuid(),
+    CONSTRAINT unique_library_zine_uuid UNIQUE (uuid)
+);
+
+ALTER TABLE library_zines ADD CONSTRAINT unique_library_zines_slug UNIQUE (slug);
+
+-- Function to update `updated_at` for `library_zines`
+CREATE OR REPLACE FUNCTION update_library_zines_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger for `library_zines` to update `updated_at`
+CREATE TRIGGER set_updated_at
+BEFORE UPDATE ON public.library_zines
+FOR EACH ROW
+EXECUTE FUNCTION update_library_zines_updated_at_column();
+
+
+CREATE TABLE public.authors (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    url TEXT,
+    bio TEXT,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE public.library_zines_authors (
+    id SERIAL PRIMARY KEY,
+    zine_id INT NOT NULL,
+    author_id INT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+
+    CONSTRAINT fk_library_zines FOREIGN KEY (zine_id) REFERENCES public.library_zines (id) ON DELETE CASCADE,
+    CONSTRAINT fk_authors FOREIGN KEY (author_id) REFERENCES public.authors (id) ON DELETE CASCADE,
+    
+    UNIQUE (zine_id, author_id)
+);
+
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_updated_at
+BEFORE UPDATE ON public.authors
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();
+
+COMMIT;


### PR DESCRIPTION
Essa pr adiciona:
- Migration para as tabelas de authors e para o relacionamento com as zines
- Gerado os arquivos de tipagem do supabase
-  Criação de novas tabelas: form_uploads e library_zines, pra facilitar a migração de dados

Obs.: Já foi sincronizado as migrations dessa PR com o supabase usando o comando npx supabase db push


Pra tudo funfar certinho eu precisei criar um script em python que pega os dados do CSV das respostas do form e faz toda a batucada de: gerar os slugs, separar os autores, dar os inserts necessários pra fazer os vínculos no nosso banco etc etc (uma leve viagem)

![image](https://github.com/user-attachments/assets/17d475d4-f77b-43a8-8bff-1d850d620552)


![image](https://github.com/user-attachments/assets/fcfed7a6-ed03-4260-af38-5a10af6f5346)


Como o script faz conexão direto com o banco de dados, por segurança não commitei ele nessa PR,  mas ele vai ficar obsoleto quando deixarmos o cadastro de zines dentro do site ao invés de usando o google forms

Closes #37
Closes #6 
Closes #41