### PR TITLE
add slug as indetifier to zine preview

### DIFF
--- a/build-bash.sh
+++ b/build-bash.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"

--- a/e2e/zines/preview.spec.ts
+++ b/e2e/zines/preview.spec.ts
@@ -1,22 +1,24 @@
 import it from '@playwright/test';
 
-it.describe('/zines/[id] Page', () => {
-  const validZineUuid = '76dfa9a9-fa0a-4288-8bf5-5ee3637e8951';
-  const invalidZineUuid = 'invalid-id';
+it.describe('/zines/[slug] Page', () => {
+  const validZineSlug = 'luana-goes-girlhood';
+  const invalidZineSlug = 'invalid-slug';
 
-  it('renders zine details for a valid uuid', async ({ page }) => {
-    await page.goto(`/zines/${validZineUuid}`);
+  it('renders zine details for a valid slug', async ({ page }) => {
+    await page.goto(`/zines/${validZineSlug}`);
     await it.expect(page.locator('text=girlhood')).toBeVisible();
-    await it.expect(page.locator('text=Luana Góes')).toBeVisible();
+    await it.expect(page.getByRole('link', { name: 'Conhecer autor: Luana Góes' })).toBeVisible();
   });
 
-  it('displays error message for an invalid uuid', async ({ page }) => {
-    await page.goto(`/zines/${invalidZineUuid}`);
+  it('displays error message for an invalid slug', async ({ page }) => {
+    await page.goto(`/zines/${invalidZineSlug}`);
     await it.expect(page.locator('text=Ops! Parece que algo deu errado')).toBeVisible();
     await it.expect(page.locator('text=Voltar para a página inicial')).toBeVisible();
 
     await page.click('text=Voltar para a página inicial');
     await it.expect(page).toHaveURL('/');
-    await it.expect(page.locator('text=Biblioteca de Zines')).toBeVisible();
+    await it.expect(page.locator('h1:text("Biblioteca de Zines")')).toBeVisible();
   });
+
+
 });

--- a/src/app/zines/[slug]/page.tsx
+++ b/src/app/zines/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import PDFViewer from "@/components/pdf-viewer";
-import { getZineByUuid } from "@/services/zine-service";
+import { getZineBySlug } from "@/services/zine-service";
 import { getPreviewUrl, getThumbnailUrl } from "@/utils/assets";
 import { joinAuthors, limitText } from "@/utils/utils";
 import Link from "next/link";
@@ -7,10 +7,10 @@ import Link from "next/link";
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ id: string }>;
+  params: Promise<{ slug: string }>;
 }) {
-  const { id } = await params;
-  const preview = await getZineByUuid(id);
+  const { slug } = await params;
+  const preview = await getZineBySlug(slug);
 
   if (!preview) {
     return {
@@ -32,11 +32,11 @@ export async function generateMetadata({
       images: [
         {
           url: thumbnailUrl,
-          width: 1200,
+          wslugth: 1200,
           height: 630,
         },
       ],
-      url: `https://biblioteca-de-zines.vercel.app/zine/${id}`,
+      url: `https://biblioteca-de-zines.vercel.app/zine/${slug}`,
       type: "article",
     },
     twitter: {
@@ -51,11 +51,11 @@ export async function generateMetadata({
 export default async function ZinePreview({
   params,
 }: {
-  params: Promise<{ id: string }>;
+  params: Promise<{ slug: string }>;
 }) {
-  const { id } = await params;
+  const { slug } = await params;
 
-  const preview = await getZineByUuid(id);
+  const preview = await getZineBySlug(slug);
 
   if (!preview) {
     return (

--- a/src/app/zines/[slug]/page.tsx
+++ b/src/app/zines/[slug]/page.tsx
@@ -32,7 +32,7 @@ export async function generateMetadata({
       images: [
         {
           url: thumbnailUrl,
-          wslugth: 1200,
+          width: 1200,
           height: 630,
         },
       ],

--- a/src/components/zine-card.tsx
+++ b/src/components/zine-card.tsx
@@ -34,7 +34,7 @@ const ZineCard: React.FC<ZineCardProps> = ({ zine }) => {
 
       <div className="flex flex-col md:flex-row justify-center gap-2 p-4">
         <Link
-          href={`/zines/${zine.uuid}`}
+          href={`/zines/${zine.slug}`}
           className="flex items-center justify-center px-3 py-1.5 text-sm font-medium text-white bg-black rounded-md hover:bg-gray-800 transition"
         >
           Ver mais

--- a/src/services/zine-service.ts
+++ b/src/services/zine-service.ts
@@ -1,6 +1,5 @@
 import { Zine } from "@/@types/zine";
 import { createClient } from "@/utils/supabase/server";
-import { isUuid } from "@/utils/utils";
 import { PostgrestResponse } from "@supabase/supabase-js";
 
 export const getPublishedZines = async (): Promise<Zine[]> => {

--- a/src/services/zine-service.ts
+++ b/src/services/zine-service.ts
@@ -1,5 +1,6 @@
 import { Zine } from "@/@types/zine";
 import { createClient } from "@/utils/supabase/server";
+import { isUuid } from "@/utils/utils";
 import { PostgrestResponse } from "@supabase/supabase-js";
 
 export const getPublishedZines = async (): Promise<Zine[]> => {
@@ -20,7 +21,7 @@ export const getPublishedZines = async (): Promise<Zine[]> => {
   return data ?? [];
 };
 
-export const getZineByUuid = async (uuid: string): Promise<Zine | null> => {
+export const getZineBySlug = async (slug: string): Promise<Zine | null> => {
   const supabase = await createClient();
 
   const { data, error } = await supabase
@@ -28,13 +29,13 @@ export const getZineByUuid = async (uuid: string): Promise<Zine | null> => {
     .select(
       '*, library_zines_authors (authors (id, name, url))'
     )
-    .eq("uuid", uuid)
+    .eq("slug", slug)
     .eq("is_published", true)
     .single();
 
   if (error) {
     console.error("Error fetching zine by slug:", error.message);
-    throw new Error(error.message);
+    throw new Error('Não foi possível encontrar a zine.');
   } 
 
   return data ?? null;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -26,8 +26,3 @@ export function joinAuthors(
 ): string {
   return library_zines_authors.map((a) => a.authors.name).join(", ");
 }
-
-export function isUuid(string:string){
-  const validUuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-  return validUuidRegex.test(string);
-}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -26,3 +26,8 @@ export function joinAuthors(
 ): string {
   return library_zines_authors.map((a) => a.authors.name).join(", ");
 }
+
+export function isUuid(string:string){
+  const validUuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  return validUuidRegex.test(string);
+}


### PR DESCRIPTION
Essa pr contém:
- Troca de uuid para slug na rota de exibição da zine
- Remoção de arquivo desnecessário de build
- Correção de testes para nova estrutura 

Obs.: Eu acho que a preview da vercel só pode ter acesso uma pessoa (no caso eu que sou dona do projeto), podemos criar uma issue pra subir tudão pra outra plataforma e já resolver esse fluxo de CI/CD 

https://github.com/user-attachments/assets/b7ef89a6-4bc1-49ca-9ae4-678d270c2dfe


